### PR TITLE
Make build possible on ZorinOS

### DIFF
--- a/drivers/gpu/drm/amd/dkms/Makefile
+++ b/drivers/gpu/drm/amd/dkms/Makefile
@@ -22,7 +22,7 @@ OS_NAME = "unknown"
 OS_VERSION = "0.0"
 endif
 
-ifneq ($(findstring $(OS_NAME), "ubuntu" "sled" "sles" "opensuse" "opensuse-leap" "amzn" "custom-rhel"),)
+ifneq ($(findstring $(OS_NAME), "ubuntu" "zorin" "sled" "sles" "opensuse" "opensuse-leap" "amzn" "custom-rhel"),)
 DRM_VER=$(shell sed -n 's/^VERSION = \(.*\)/\1/p' $(kdir)/Makefile)
 DRM_PATCH=$(shell sed -n 's/^PATCHLEVEL = \(.*\)/\1/p' $(kdir)/Makefile)
 else ifeq ("debian", $(OS_NAME))


### PR DESCRIPTION
DKMS module successfully builds on ZorinOS 15, but needs a slight modification.