### PR TITLE
sgprs initialization: log and continue patch

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
@@ -2898,7 +2898,7 @@ static int __init amdgpu_init(void)
 
 	DRM_INFO("amdgpu kernel modesetting enabled.\n");
 
-	DRM_INFO("amdgpu version: %s\n", AMDGPU_VERSION);
+	DRM_INFO("amdgpu version patched: %s\n", AMDGPU_VERSION);
 	DRM_INFO("OS DRM version: %d.%d.%d\n", DRM_VER, DRM_PATCH, DRM_SUB);
 
 	amdgpu_register_atpx_handler();

--- a/drivers/gpu/drm/amd/amdgpu/gfx_v9_4_2.c
+++ b/drivers/gpu/drm/amd/amdgpu/gfx_v9_4_2.c
@@ -558,7 +558,7 @@ static int gfx_v9_4_2_do_sgprs_init(struct amdgpu_device *adev)
 	if (r) {
 		dev_err(adev->dev, "wave coverage failed when clear first 576 sgprs\n");
 		wb_ib.ptr[0] = 0xdeadbeaf; /* stop waves */
-		goto disp1_failed;
+		/* continue initialization */
 	}
 
 	wb_ib.ptr[0] = 0xdeadbeaf; /* stop waves */
@@ -567,13 +567,13 @@ static int gfx_v9_4_2_do_sgprs_init(struct amdgpu_device *adev)
 	r = dma_fence_wait(fences[0], false);
 	if (r) {
 		dev_err(adev->dev, "timeout to clear first 224 sgprs\n");
-		goto disp1_failed;
+		/* continue initialization */
 	}
 
 	r = dma_fence_wait(fences[1], false);
 	if (r) {
 		dev_err(adev->dev, "timeout to clear first 576 sgprs\n");
-		goto disp1_failed;
+		/* continue initialization */
 	}
 
 	memset(wb_ib.ptr, 0, (1 + wb_size) * sizeof(uint32_t));


### PR DESCRIPTION
Patch for SGPRS initialization failure to log and continue rest of initialization instead of goto end