### PR TITLE
drm/amdkfd: account for non-KFD DRM VRAM residency

### DIFF
--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd.h
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd.h
@@ -113,6 +113,8 @@ struct amdgpu_kfd_dev {
 	int64_t vram_used[MAX_XCP];
 	uint64_t vram_used_aligned[MAX_XCP];
 	atomic64_t vram_pinned;
+	atomic64_t drm_vram_used[MAX_XCP];
+	atomic64_t unaccounted_vram_pinned;
 	bool init_complete;
 	struct work_struct reset_work;
 

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_gpuvm.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_amdkfd_gpuvm.c
@@ -235,9 +235,19 @@ int amdgpu_amdkfd_reserve_mem_limit(struct amdgpu_device *adev,
 	 */
 
 	if (adev && xcp_id >= 0 && (!adev->apu_prefer_gtt || adev->gmc.is_app_apu)) {
-		uint64_t vram_available =
-			vram_size - reserved_for_pt - reserved_for_ras -
-			atomic64_read(&adev->vram_pin_size);
+		u64 vram_available;
+
+		if (!(adev->flags & AMD_IS_APU) && !adev->gmc.mem_partitions) {
+			u64 vram_unavailable = reserved_for_pt + reserved_for_ras +
+				atomic64_read(&adev->kfd.unaccounted_vram_pinned) +
+				amdgpu_vram_mgr_kfd_available_usage(adev, xcp_id);
+
+			vram_available = vram_size > vram_unavailable ?
+				vram_size - vram_unavailable : 0;
+		} else {
+			vram_available = vram_size - reserved_for_pt - reserved_for_ras -
+				atomic64_read(&adev->vram_pin_size);
+		}
 		if (adev->kfd.vram_used[xcp_id] + vram_needed > vram_available) {
 			ret = -ENOMEM;
 			goto release;
@@ -1769,18 +1779,28 @@ size_t amdgpu_amdkfd_get_available_memory(struct amdgpu_device *adev,
 	uint64_t reserved_for_ras = (con ? con->reserved_pages_in_bytes : 0);
 	ssize_t available;
 	uint64_t vram_available, system_mem_available, ttm_mem_available;
+	u64 vram_unavailable;
 
 	spin_lock(&kfd_mem_limit.mem_limit_lock);
 	if (adev->apu_prefer_gtt && !adev->gmc.is_app_apu)
 		vram_available = KFD_XCP_MEMORY_SIZE(adev, xcp_id)
 			- adev->kfd.vram_used_aligned[xcp_id];
-	else
+	else if (!(adev->flags & AMD_IS_APU) && !adev->gmc.mem_partitions) {
+		vram_unavailable = adev->kfd.vram_used_aligned[xcp_id] +
+			atomic64_read(&adev->kfd.unaccounted_vram_pinned) +
+			amdgpu_vram_mgr_kfd_available_usage(adev, xcp_id) +
+			reserved_for_pt + reserved_for_ras;
+		vram_available = KFD_XCP_MEMORY_SIZE(adev, xcp_id) >
+			vram_unavailable ? KFD_XCP_MEMORY_SIZE(adev, xcp_id) -
+			vram_unavailable : 0;
+	} else {
 		vram_available = KFD_XCP_MEMORY_SIZE(adev, xcp_id)
 			- adev->kfd.vram_used_aligned[xcp_id]
 			- atomic64_read(&adev->vram_pin_size)
 			+ atomic64_read(&adev->kfd.vram_pinned)
 			- reserved_for_pt
 			- reserved_for_ras;
+	}
 
 	if (adev->apu_prefer_gtt) {
 		system_mem_available = no_system_mem_limit ?
@@ -1877,6 +1897,8 @@ int amdgpu_amdkfd_gpuvm_alloc_memory_of_gpu(
 		alloc_flags |= AMDGPU_GEM_CREATE_EXT_COHERENT;
 	if (flags & KFD_IOC_ALLOC_MEM_FLAGS_UNCACHED)
 		alloc_flags |= AMDGPU_GEM_CREATE_UNCACHED;
+	if (flags & KFD_IOC_ALLOC_MEM_FLAGS_VRAM)
+		alloc_flags |= AMDGPU_AMDKFD_CREATE_VRAM_ACCOUNTED;
 
 	*mem = kzalloc(sizeof(struct kgd_mem), GFP_KERNEL);
 	if (!*mem) {

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_object.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_object.c
@@ -679,7 +679,9 @@ int amdgpu_bo_create(struct amdgpu_device *adev,
 	    bo->allowed_domains == AMDGPU_GEM_DOMAIN_VRAM)
 		bo->allowed_domains |= AMDGPU_GEM_DOMAIN_GTT;
 
-	bo->flags = bp->flags;
+	bo->kfd_vram_accounted = bp->flags &
+		AMDGPU_AMDKFD_CREATE_VRAM_ACCOUNTED;
+	bo->flags = bp->flags & ~AMDGPU_AMDKFD_CREATE_VRAM_ACCOUNTED;
 
 	if (adev->gmc.mem_partitions)
 		/* For GPUs with spatial partitioning, bo->xcp_id=-1 means any partition */
@@ -1002,6 +1004,11 @@ int amdgpu_bo_pin(struct amdgpu_bo *bo, u32 domain)
 
 	if (bo->tbo.resource->mem_type == TTM_PL_VRAM) {
 		atomic64_add(amdgpu_bo_size(bo), &adev->vram_pin_size);
+		if (!(adev->flags & AMD_IS_APU) && !adev->gmc.mem_partitions &&
+		    !bo->kfd_vram_accounted &&
+		    !amdgpu_vram_mgr_bo_kfd_available_accounted(bo))
+			atomic64_add(amdgpu_bo_size(bo),
+				     &adev->kfd.unaccounted_vram_pinned);
 		atomic64_add(amdgpu_vram_mgr_bo_visible_size(bo),
 			     &adev->visible_pin_size);
 	} else if (bo->tbo.resource->mem_type == TTM_PL_TT) {
@@ -1036,6 +1043,11 @@ void amdgpu_bo_unpin(struct amdgpu_bo *bo)
 #endif
 
 	if (bo->tbo.resource->mem_type == TTM_PL_VRAM) {
+		if (!(adev->flags & AMD_IS_APU) && !adev->gmc.mem_partitions &&
+		    !bo->kfd_vram_accounted &&
+		    !amdgpu_vram_mgr_bo_kfd_available_accounted(bo))
+			atomic64_sub(amdgpu_bo_size(bo),
+				     &adev->kfd.unaccounted_vram_pinned);
 		atomic64_sub(amdgpu_bo_size(bo), &adev->vram_pin_size);
 		atomic64_sub(amdgpu_vram_mgr_bo_visible_size(bo),
 			     &adev->visible_pin_size);

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_object.h
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_object.h
@@ -39,6 +39,8 @@
 #define AMDGPU_BO_INVALID_OFFSET	LONG_MAX
 #define AMDGPU_BO_MAX_PLACEMENTS	3
 
+/* BO flag to indicate VRAM already accounted by KFD */
+#define AMDGPU_AMDKFD_CREATE_VRAM_ACCOUNTED	BIT_ULL(62)
 /* BO flag to indicate a KFD userptr BO */
 #define AMDGPU_AMDKFD_CREATE_USERPTR_BO	(1ULL << 63)
 
@@ -127,6 +129,7 @@ struct amdgpu_bo {
 #endif
 
 	struct kgd_mem                  *kfd_bo;
+	bool				kfd_vram_accounted;
 
 	/*
 	 * For GPUs with spatial partitioning, xcp partition number, -1 means

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_vram_mgr.c
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_vram_mgr.c
@@ -90,6 +90,24 @@ static inline u64 amdgpu_vram_mgr_blocks_size(struct list_head *head)
 	return size;
 }
 
+u64 amdgpu_vram_mgr_kfd_available_usage(struct amdgpu_device *adev,
+					s8 xcp_id)
+{
+	if (xcp_id < 0 || xcp_id >= MAX_XCP)
+		return 0;
+
+	return atomic64_read(&adev->kfd.drm_vram_used[xcp_id]);
+}
+
+bool amdgpu_vram_mgr_bo_kfd_available_accounted(struct amdgpu_bo *bo)
+{
+	if (!bo->tbo.resource || bo->tbo.resource->mem_type != TTM_PL_VRAM)
+		return false;
+
+	return to_amdgpu_vram_mgr_resource(bo->tbo.resource)->
+		kfd_available_accounted;
+}
+
 /**
  * DOC: mem_info_vram_total
  *
@@ -615,6 +633,14 @@ static int amdgpu_vram_mgr_new(struct ttm_resource_manager *man,
 	else
 		vres->base.bus.caching = ttm_write_combined;
 
+	vres->kfd_available_xcp_id = bo->xcp_id;
+	if (tbo->type == ttm_bo_type_device &&
+	    !bo->kfd_vram_accounted &&
+	    bo->xcp_id >= 0 && bo->xcp_id < MAX_XCP &&
+	    !(adev->flags & AMD_IS_APU) && !adev->gmc.mem_partitions) {
+		atomic64_add(vres->base.size, &adev->kfd.drm_vram_used[bo->xcp_id]);
+		vres->kfd_available_accounted = true;
+	}
 	atomic64_add(vis_usage, &mgr->vis_usage);
 	*res = &vres->base;
 	return 0;
@@ -660,6 +686,9 @@ static void amdgpu_vram_mgr_del(struct ttm_resource_manager *man,
 	mutex_unlock(&mgr->lock);
 
 	atomic64_sub(vis_usage, &mgr->vis_usage);
+	if (vres->kfd_available_accounted)
+		atomic64_sub(vres->base.size,
+			     &adev->kfd.drm_vram_used[vres->kfd_available_xcp_id]);
 
 	ttm_resource_fini(man, res);
 	kfree(vres);

--- a/drivers/gpu/drm/amd/amdgpu/amdgpu_vram_mgr.h
+++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_vram_mgr.h
@@ -26,6 +26,9 @@
 
 #include <drm/drm_buddy.h>
 
+struct amdgpu_bo;
+struct amdgpu_device;
+
 struct amdgpu_vram_mgr {
 	struct ttm_resource_manager manager;
 	struct drm_buddy mm;
@@ -55,6 +58,8 @@ struct amdgpu_vram_mgr_resource {
 	unsigned long flags;
 	struct list_head vres_node;
 	struct amdgpu_vres_task task;
+	s8 kfd_available_xcp_id;
+	bool kfd_available_accounted;
 };
 
 static inline u64 amdgpu_vram_mgr_block_start(struct drm_buddy_block *block)
@@ -88,5 +93,8 @@ static inline void amdgpu_vram_mgr_set_cleared(struct ttm_resource *res)
 
 int amdgpu_vram_mgr_query_address_block_info(struct amdgpu_vram_mgr *mgr,
 		uint64_t address, struct amdgpu_vram_block_info *info);
+u64 amdgpu_vram_mgr_kfd_available_usage(struct amdgpu_device *adev,
+					s8 xcp_id);
+bool amdgpu_vram_mgr_bo_kfd_available_accounted(struct amdgpu_bo *bo);
 
 #endif

--- a/drivers/gpu/drm/amd/amdkfd/kfd_svm.c
+++ b/drivers/gpu/drm/amd/amdkfd/kfd_svm.c
@@ -598,7 +598,8 @@ svm_range_vram_node_new(struct kfd_node *node, struct svm_range *prange,
 	bp.size = prange->npages * PAGE_SIZE;
 	bp.byte_align = PAGE_SIZE;
 	bp.domain = AMDGPU_GEM_DOMAIN_VRAM;
-	bp.flags = AMDGPU_GEM_CREATE_NO_CPU_ACCESS;
+	bp.flags = AMDGPU_GEM_CREATE_NO_CPU_ACCESS |
+		AMDGPU_AMDKFD_CREATE_VRAM_ACCOUNTED;
 	bp.flags |= clear ? AMDGPU_GEM_CREATE_VRAM_CLEARED : 0;
 	bp.flags |= AMDGPU_GEM_CREATE_DISCARDABLE;
 	bp.type = ttm_bo_type_device;


### PR DESCRIPTION
Fixes #223.

## Summary

KFD available-memory accounting does not include unpinned VRAM resident through
other DRM clients, so `hipMemGetInfo` can over-report free VRAM on Linux dGPUs.

Track non-KFD user BO residency with the VRAM resource lifetime and subtract it
from the KFD query and allocation limit. Mark BOs already represented by KFD
accounting to avoid double counting, and leave APU and memory-partition paths
unchanged.

## Validation

- RX 7900 GRE / gfx1100, ROCm 7.2.1, Ubuntu kernels 6.14 and 7.0.
- Baseline: a 256 MiB libdrm VRAM BO reduced DRM free by 256 MiB and KFD free by
  0 B.
- Patched module: the same allocation reduced both values by 256 MiB in 3/3
  runs; KFD allocation/free behavior remained unchanged.
- Current `master` built a SVM-enabled `amdgpu.o`; strict `checkpatch.pl`
  reported 0 errors, 0 warnings, and 0 checks.

APU and XCP/memory-partition runtime coverage is not included yet.

---
*This is an experimental, AI-generated code change, reviewed by AMD engineers before submission.*